### PR TITLE
Replaced various Replace()-calls with Sanitize()

### DIFF
--- a/bcc.bmx
+++ b/bcc.bmx
@@ -26,6 +26,7 @@ SuperStrict
 Framework brl.StandardIO
 
 Import "ctranslator.bmx"
+Import "base.stringhelper.bmx"
 
 Local args:String[] = ParseArgs(AppArgs[1..])
 
@@ -96,7 +97,7 @@ Function SaveHeader(file:String, trans:TCTranslator, mung:String)
 
 	Local path:String = OutputFilePath(file, mung, "h")
 
-	Local header:String = BuildHeaderName(path).ToUpper().Replace(".", "_").Replace("-","_")
+	Local header:String = BuildHeaderName(path).ToUpper()
 	Local text:String = HeaderComment()
 	text :+ "#ifndef " + header + "~n"
 	text :+ "#define " + header + "~n~n"

--- a/config.bmx
+++ b/config.bmx
@@ -28,6 +28,7 @@ Import BRL.Map
 Import BRL.FileSystem
 
 Import "options.bmx"
+Import "base.stringhelper.bmx"
 
 
 ' debugging help
@@ -218,19 +219,18 @@ End Function
 
 Function BuildHeaderName:String(path:String)
 	If opt_buildtype = BUILDTYPE_MODULE Then
-		path = opt_modulename + "." + StripDir(path)
+		path = opt_modulename + "_" + StripDir(path)
 	Else
 		Local dir:String = ExtractDir(path).ToLower().Replace("/.bmx","")
 		dir = dir[dir.findLast("/") + 1..]
 		If dir.EndsWith(".mod") Then
 			dir = dir.Replace(".mod", "")
 		End If
-		dir = dir.Replace(".", "_").Replace("-", "_")
 		Local file:String = StripDir(path).ToLower()
 		path = dir + "_" + file
 	End If
 	
-	Return path
+	Return TStringHelper.Sanitize(path)
 End Function
 
 Rem

--- a/ctranslator.bmx
+++ b/ctranslator.bmx
@@ -2983,9 +2983,8 @@ End Rem
 			result = "_bb_" + mdecl.ident
 		End If
 
-		'remove non-allowed characters
-		result = result.Replace(".", "_").Replace("-", "_")
-		Return result
+		'return with all non-allowed chars (like "-" or " ") removed
+		Return TStringHelper.Sanitize(result)
 	End Method
 
 	Method TransInterface(app:TAppDecl)

--- a/iparser.bmx
+++ b/iparser.bmx
@@ -26,6 +26,8 @@ SuperStrict
 Import BRL.MaxUtil
 
 Import "toker.bmx"
+Import "base.stringhelper.bmx"
+
 Rem
 Global globalMod:TModuleDecl = New TModuleDecl.Create("brl.global", "bbGlobal", "", 0)
 
@@ -174,12 +176,13 @@ DebugLog "FILE NOT FOUND : " + ipath
 							If dir.EndsWith(".mod") Then
 								dir = ""
 							Else
-								dir = dir.Replace(".", "_").Replace("-", "_") + "_"
+								dir :+ "_"
 							End If
 							Local file:String = StripDir(origPath).ToLower()
 			
 							modpath = opt_modulename + "_" + dir + StripExt(file)
-							modpath = modpath.ToLower().Replace(".", "_").Replace("-", "_")
+							'sanitize the path, remove non-allowed chars
+							modpath = TStringHelper.Sanitize(modpath.ToLower())
 						Else
 							' todo file imports for apps
 							'internalErr

--- a/parser.bmx
+++ b/parser.bmx
@@ -2237,16 +2237,17 @@ End Rem
 				If dir.EndsWith(".mod") Then
 					dir = ""
 				Else
-					dir = dir.Replace(".", "_").Replace("-", "_") + "_"
+					dir :+ "_"
 				End If
 				Local file:String = StripDir(origPath).ToLower()
 
 				modpath = opt_modulename + "_" + dir + StripExt(file)
-				modpath = modpath.ToLower().Replace(".", "_").Replace("-", "_")
 			Else
 				modpath = StripExt(filepath)
-				modpath = modpath.ToLower().Replace(".", "_").Replace("-", "_")
 			End If
+
+			'sanitize the path, remove non-allowed chars
+			modpath = TStringHelper.Sanitize(modpath.ToLower())
 
 			' try to import interface
 			Local par:TIParser = New TIParser
@@ -2363,12 +2364,13 @@ End Rem
 				If dir.EndsWith(".mod") Then
 					dir = dir.Replace(".mod", "")
 				End If
-				dir = dir.Replace(".", "_").Replace("-", "_")
 				Local file:String = StripDir(opt_filepath).ToLower()
 				app.munged = "_bb_" + dir + "_" + StripExt(file)
 			End If
 		End If
-		app.munged = app.munged.Replace(".", "_").Replace("-", "_")
+
+		'sanitize, remove non-allowed chars
+		app.munged = TStringHelper.Sanitize(app.munged)
 	End Method
 
 	' load external cast defs
@@ -2662,10 +2664,11 @@ endrem
 			Else
 				dir :+ "_"
 			End If
-			dir = dir.Replace(".", "_").Replace("-", "_")
 
 			munged = opt_modulename + "_" + dir + ident
-			munged = munged.ToLower().Replace(".", "_").Replace("-", "_")
+
+			'sanitize, remove non-allowed chars
+			munged = TStringHelper.Sanitize(munged.ToLower())
 		End If
 
 		If opt_ismain Then 'And opt_modulename <> "brl.blitz" Then
@@ -2762,7 +2765,8 @@ endrem
 					Err "Module does not match commandline module"
 				End If
 
-				_module.munged = m.Replace(".", "_").Replace("-", "_")
+				'sanitize, remove non-allowed chars
+				_module.munged = TStringHelper.Sanitize(m)
 			Case "rem"
 				ParseRemStmt()
 			Case "nodebug"
@@ -3017,10 +3021,10 @@ Function ParseApp:TAppDecl( path$ )
 End Function
 
 Function MungModuleName:String(ident:Object)
+	local mung:String
 	If String(ident) Then
 		Local id:String = String(ident)
-		Local mung:String = "__bb_" + id + "_" + id[id.Find(".") + 1..]
-		Return mung.Replace(".", "_").Replace("-", "_")
+		mung = "__bb_" + id + "_" + id[id.Find(".") + 1..]
 	Else
 		Local mdecl:TModuleDecl = TModuleDecl(ident)
 		If mdecl Then
@@ -3032,10 +3036,12 @@ Function MungModuleName:String(ident:Object)
 			Else
 				dir :+ "_"
 			End If
-			Local mung:String = "__bb_" + id + "_" + dir + id[id.Find(".") + 1..]
-			Return mung.Replace(".", "_").Replace("-", "_")
+			mung = "__bb_" + id + "_" + dir + id[id.Find(".") + 1..]
 		End If
 	End If
+
+	'return sanitized, remove non-allowed chars
+	return TStringHelper.Sanitize(mung)
 End Function
 
 Function EvalS$( source$,ty:TType )

--- a/translator.bmx
+++ b/translator.bmx
@@ -131,7 +131,6 @@ Type TTranslator
 
 			If TModuleDecl( decl )
 				munged=decl.ModuleScope().munged+"_"+id
-				munged = munged.Replace(".", "_").Replace("-", "_")
 			EndIf
 
 '		End Select
@@ -153,16 +152,20 @@ Type TTranslator
 			EndIf
 		EndIf
 		
+		'sanitize non-mung-able characters
+		munged = TStringHelper.Sanitize(munged)
+
+
+		'add an increasing number to identifier if already used  
 		If mungScope.Contains( munged )
-			Local t$,i:Int=1
+			Local i:Int=1
 			Repeat
 				i:+1
-				t=munged+i
-			Until Not mungScope.Contains( t )
-			munged=t
+			Until Not mungScope.Contains( munged + i )
+			munged :+ i
 		EndIf
 
-		mungScope.Insert munged,decl
+		mungScope.Insert(munged, decl)
 		decl.munged=munged
 		
 		' a function pointers' real function is stored in "func" - need to set its munged to match the parent.


### PR DESCRIPTION
- replaced Replace("-","_").Replace(".","_") with a more convenient TStringHelper.Sanitize() which takes care of all nonalphanumerical chars. Without additional params everything "non-valid" is replaced with the underscore "_" character (so an existing "_" is replaced with "_" - which gets rid of the need to write more parameters than needed)
- added some small tweaks avoiding multiple Sanitize-calls (Sanitize only once instead in if-then-else + end)
