### PR TITLE
Exit after printing the bcc-version.

### DIFF
--- a/bcc.bmx
+++ b/bcc.bmx
@@ -31,6 +31,7 @@ Local args:String[] = ParseArgs(AppArgs[1..])
 
 If args.length = 0 Then
 	Print "bcc[ng] Release Version " + version
+	End
 End If
 
 If args.length <> 1 Then


### PR DESCRIPTION
This fix enables using bcc[ng] debug version with bmk[ng]. Without this patch bcc will throw an error and wait for debugging with no commands given (as used by bmk[ng] to determine the bcc version.)