### PR TITLE
Added more information when an included file isn't found/readable.

### DIFF
--- a/parser.bmx
+++ b/parser.bmx
@@ -3140,6 +3140,10 @@ End Rem
 				'instead of merging the data of multiple parsers, the
 				'same parser is used for all included files - but each
 				'of them uses an individual toker
+				
+				If FileType( includeFile )<>FILETYPE_FILE
+					DoErr "File '"+ includeFile +"' not found."
+				EndIf
 
 				'instead of "LoadText" "PreProcess" is used to include
 				'handling of conditionals and comments

--- a/parser.bmx
+++ b/parser.bmx
@@ -3143,20 +3143,24 @@ End Rem
 
 				'instead of "LoadText" "PreProcess" is used to include
 				'handling of conditionals and comments
-				Local includeSource:String = PreProcess(includeFile)
-				Local includeToker:TToker = New TToker.Create(includeFile, includeSource)
-
-				'backup old vars
-				Local oldToker:TToker = Self._toker
-
-				'assign temporary vars
-				Self._toker = includeToker
-
-				'parse the include file
-				parseCurrentFile(includeFile, attrs)
-
-				'restore backup vars
-				Self._toker = oldToker
+				Try
+					Local includeSource:String = PreProcess(includeFile)
+					Local includeToker:TToker = New TToker.Create(includeFile, includeSource)
+	
+					'backup old vars
+					Local oldToker:TToker = Self._toker
+	
+					'assign temporary vars
+					Self._toker = includeToker
+	
+					'parse the include file
+					parseCurrentFile(includeFile, attrs)
+	
+					'restore backup vars
+					Self._toker = oldToker
+				Catch e:TStreamException
+					DoErr "include read error - include '" + includeFile + "' raised: '" + e.ToString() + "'"
+				End Try
 
 				'move on to next toke (after include "xyz.bmx")
 				NextToke


### PR DESCRIPTION
I stumbled across the problem of misspelling an include `Include "../mod/bah/libxml.mod/libxml.bmx"` I just forgot the ".mod".
But the error reported by bcc just said `Unhandled Exception:Error reading from stream`. Without even the slightest direction to where/why this error was raised (risen?! past of "to raise").

**Feel free to suggest a better message for this DoErr.** than `include read error - include '" + includeFile + "' raised: '" + e.ToString() + "'`
