### PR TITLE
Fix: Cast booleans to ints if using them as int

### DIFF
--- a/parser.bmx
+++ b/parser.bmx
@@ -3688,59 +3688,59 @@ End Rem
 	env.InsertDecl New TConstDecl.Create( "threaded",New TIntType,New TConstExpr.Create( New TIntType,opt_threaded ),0 )
 
 	' macos
-	env.InsertDecl New TConstDecl.Create( "macos",New TIntType,New TConstExpr.Create( New TIntType,opt_platform="macos" ),0 )
-	env.InsertDecl New TConstDecl.Create( "macosx86",New TIntType,New TConstExpr.Create( New TIntType,opt_platform="macos" And opt_arch="x86"),0 )
-	env.InsertDecl New TConstDecl.Create( "macosppc",New TIntType,New TConstExpr.Create( New TIntType,opt_platform="macos" And opt_arch="ppc"),0 )
-	env.InsertDecl New TConstDecl.Create( "macosx64",New TIntType,New TConstExpr.Create( New TIntType,opt_platform="macos" And opt_arch="x64"),0 )
+	env.InsertDecl New TConstDecl.Create( "macos",New TIntType,New TConstExpr.Create( New TIntType,Int(opt_platform="macos")),0 )
+	env.InsertDecl New TConstDecl.Create( "macosx86",New TIntType,New TConstExpr.Create( New TIntType, Int(opt_platform="macos" And opt_arch="x86")),0 )
+	env.InsertDecl New TConstDecl.Create( "macosppc",New TIntType,New TConstExpr.Create( New TIntType, Int(opt_platform="macos" And opt_arch="ppc")),0 )
+	env.InsertDecl New TConstDecl.Create( "macosx64",New TIntType,New TConstExpr.Create( New TIntType, Int(opt_platform="macos" And opt_arch="x64")),0 )
 
 	' windows
-	env.InsertDecl New TConstDecl.Create( "win32",New TIntType,New TConstExpr.Create( New TIntType,opt_platform="win32" ),0 )
-	env.InsertDecl New TConstDecl.Create( "win32x86",New TIntType,New TConstExpr.Create( New TIntType,opt_platform="win32" And opt_arch="x86"),0 )
-	env.InsertDecl New TConstDecl.Create( "win32x64",New TIntType,New TConstExpr.Create( New TIntType,(opt_platform="win64" And opt_arch="x64") Or (opt_platform="win32" And opt_arch="x64")),0 )
-	env.InsertDecl New TConstDecl.Create( "win64",New TIntType,New TConstExpr.Create( New TIntType,(opt_platform="win64" And opt_arch="x64") Or (opt_platform="win32" And opt_arch="x64")),0 )
+	env.InsertDecl New TConstDecl.Create( "win32",New TIntType, New TConstExpr.Create( New TIntType, Int(opt_platform="win32" ) ),0 )
+	env.InsertDecl New TConstDecl.Create( "win32x86",New TIntType, New TConstExpr.Create( New TIntType, Int(opt_platform="win32" And opt_arch="x86") ),0 )
+	env.InsertDecl New TConstDecl.Create( "win32x64",New TIntType, New TConstExpr.Create( New TIntType, Int((opt_platform="win64" And opt_arch="x64") Or (opt_platform="win32" And opt_arch="x64")) ),0 )
+	env.InsertDecl New TConstDecl.Create( "win64",New TIntType, New TConstExpr.Create( New TIntType, Int((opt_platform="win64" And opt_arch="x64") Or (opt_platform="win32" And opt_arch="x64")) ),0 )
 
 	' linux
-	env.InsertDecl New TConstDecl.Create( "linux",New TIntType,New TConstExpr.Create( New TIntType,(opt_platform="linux" Or opt_platform="android" Or opt_platform="raspberrypi")),0 )
-	env.InsertDecl New TConstDecl.Create( "linuxx86",New TIntType,New TConstExpr.Create( New TIntType,(opt_platform="linux" Or opt_platform="android") And opt_arch="x86"),0 )
-	env.InsertDecl New TConstDecl.Create( "linuxx64",New TIntType,New TConstExpr.Create( New TIntType,(opt_platform="linux" Or opt_platform="android") And opt_arch="x64"),0 )
-	env.InsertDecl New TConstDecl.Create( "linuxARM",New TIntType,New TConstExpr.Create( New TIntType, ((opt_platform="android" Or opt_platform="linux") And (opt_arch="arm" Or opt_arch="armeabi" Or opt_arch="armeabiv7a" Or opt_arch="arm64v8a")) Or (opt_platform="raspberrypi" And opt_arch="arm")),0 )
+	env.InsertDecl New TConstDecl.Create( "linux",New TIntType, New TConstExpr.Create( New TIntType, Int((opt_platform="linux" Or opt_platform="android" Or opt_platform="raspberrypi")) ),0 )
+	env.InsertDecl New TConstDecl.Create( "linuxx86",New TIntType, New TConstExpr.Create( New TIntType, Int((opt_platform="linux" Or opt_platform="android") And opt_arch="x86") ),0 )
+	env.InsertDecl New TConstDecl.Create( "linuxx64",New TIntType, New TConstExpr.Create( New TIntType, Int((opt_platform="linux" Or opt_platform="android") And opt_arch="x64") ),0 )
+	env.InsertDecl New TConstDecl.Create( "linuxARM",New TIntType, New TConstExpr.Create( New TIntType, Int( ((opt_platform="android" Or opt_platform="linux") And (opt_arch="arm" Or opt_arch="armeabi" Or opt_arch="armeabiv7a" Or opt_arch="arm64v8a")) Or (opt_platform="raspberrypi" And opt_arch="arm")) ),0 )
 
 	' android
-	env.InsertDecl New TConstDecl.Create( "android",New TIntType,New TConstExpr.Create( New TIntType,opt_platform="android" ),0 )
-	env.InsertDecl New TConstDecl.Create( "androidx86",New TIntType,New TConstExpr.Create( New TIntType,opt_platform="android" And opt_arch="x86"),0 )
-	env.InsertDecl New TConstDecl.Create( "androidx64",New TIntType,New TConstExpr.Create( New TIntType,opt_platform="android" And opt_arch="x64"),0 )
-	env.InsertDecl New TConstDecl.Create( "androidarm",New TIntType,New TConstExpr.Create( New TIntType,opt_platform="android" And (opt_arch="arm" Or opt_arch="armeabi" Or opt_arch="armeabiv7a" Or opt_arch="arm64v8a") ),0 )
-	env.InsertDecl New TConstDecl.Create( "androidarmeabi",New TIntType,New TConstExpr.Create( New TIntType,opt_platform="android" And opt_arch="armeabi"),0 )
-	env.InsertDecl New TConstDecl.Create( "androidarmeabiv7a",New TIntType,New TConstExpr.Create( New TIntType,opt_platform="android" And opt_arch="armeabiv7a"),0 )
-	env.InsertDecl New TConstDecl.Create( "androidarm64v8a",New TIntType,New TConstExpr.Create( New TIntType,opt_platform="android" And opt_arch="arm64v8a"),0 )
+	env.InsertDecl New TConstDecl.Create( "android",New TIntType, New TConstExpr.Create( New TIntType, Int(opt_platform="android" ) ),0 )
+	env.InsertDecl New TConstDecl.Create( "androidx86",New TIntType, New TConstExpr.Create( New TIntType, Int(opt_platform="android" And opt_arch="x86") ),0 )
+	env.InsertDecl New TConstDecl.Create( "androidx64",New TIntType, New TConstExpr.Create( New TIntType, Int(opt_platform="android" And opt_arch="x64") ),0 )
+	env.InsertDecl New TConstDecl.Create( "androidarm",New TIntType, New TConstExpr.Create( New TIntType, Int(opt_platform="android" And (opt_arch="arm" Or opt_arch="armeabi" Or opt_arch="armeabiv7a" Or opt_arch="arm64v8a") ) ),0 )
+	env.InsertDecl New TConstDecl.Create( "androidarmeabi",New TIntType, New TConstExpr.Create( New TIntType, Int(opt_platform="android" And opt_arch="armeabi") ),0 )
+	env.InsertDecl New TConstDecl.Create( "androidarmeabiv7a",New TIntType, New TConstExpr.Create( New TIntType, Int(opt_platform="android" And opt_arch="armeabiv7a") ),0 )
+	env.InsertDecl New TConstDecl.Create( "androidarm64v8a",New TIntType, New TConstExpr.Create( New TIntType, Int(opt_platform="android" And opt_arch="arm64v8a") ),0 )
 
 	' raspberrypi - ARM only
-	env.InsertDecl New TConstDecl.Create( "raspberrypi",New TIntType,New TConstExpr.Create( New TIntType,opt_platform="raspberrypi" And opt_arch="arm"),0 )
-	env.InsertDecl New TConstDecl.Create( "raspberrypiARM",New TIntType,New TConstExpr.Create( New TIntType,opt_platform="raspberrypi" And opt_arch="arm"),0 )
+	env.InsertDecl New TConstDecl.Create( "raspberrypi",New TIntType, New TConstExpr.Create( New TIntType, Int(opt_platform="raspberrypi" And opt_arch="arm") ),0 )
+	env.InsertDecl New TConstDecl.Create( "raspberrypiARM",New TIntType, New TConstExpr.Create( New TIntType, Int(opt_platform="raspberrypi" And opt_arch="arm") ),0 )
 
 	' emscripten
-	env.InsertDecl New TConstDecl.Create( "emscripten",New TIntType,New TConstExpr.Create( New TIntType,opt_platform="emscripten" ),0 )
-	env.InsertDecl New TConstDecl.Create( "emscriptenjs",New TIntType,New TConstExpr.Create( New TIntType,opt_platform="emscripten" And opt_arch="js"),0 )
+	env.InsertDecl New TConstDecl.Create( "emscripten",New TIntType, New TConstExpr.Create( New TIntType, Int(opt_platform="emscripten" ) ),0 )
+	env.InsertDecl New TConstDecl.Create( "emscriptenjs",New TIntType, New TConstExpr.Create( New TIntType, Int(opt_platform="emscripten" And opt_arch="js") ),0 )
 
 	' arch
-	env.InsertDecl New TConstDecl.Create( "ppc",New TIntType,New TConstExpr.Create( New TIntType,opt_arch="ppc" ),0 )
-	env.InsertDecl New TConstDecl.Create( "x86",New TIntType,New TConstExpr.Create( New TIntType,opt_arch="x86" ),0 )
-	env.InsertDecl New TConstDecl.Create( "x64",New TIntType,New TConstExpr.Create( New TIntType,opt_arch="x64" ),0 )
-	env.InsertDecl New TConstDecl.Create( "arm",New TIntType,New TConstExpr.Create( New TIntType,opt_arch="arm" Or opt_arch="armeabi" Or opt_arch="armeabiv7a" Or opt_arch="arm64v8a" ),0 )
-	env.InsertDecl New TConstDecl.Create( "armeabi",New TIntType,New TConstExpr.Create( New TIntType,opt_arch="armeabi" ),0 )
-	env.InsertDecl New TConstDecl.Create( "armeabiv7a",New TIntType,New TConstExpr.Create( New TIntType,opt_arch="armeabiv7a" ),0 )
-	env.InsertDecl New TConstDecl.Create( "arm64v8a",New TIntType,New TConstExpr.Create( New TIntType,opt_arch="arm64v8a" ),0 )
-	env.InsertDecl New TConstDecl.Create( "js",New TIntType,New TConstExpr.Create( New TIntType,opt_arch="js" ),0 )
+	env.InsertDecl New TConstDecl.Create( "ppc",New TIntType, New TConstExpr.Create( New TIntType, Int(opt_arch="ppc" ) ),0 )
+	env.InsertDecl New TConstDecl.Create( "x86",New TIntType, New TConstExpr.Create( New TIntType, Int(opt_arch="x86" ) ),0 )
+	env.InsertDecl New TConstDecl.Create( "x64",New TIntType, New TConstExpr.Create( New TIntType, Int(opt_arch="x64" ) ),0 )
+	env.InsertDecl New TConstDecl.Create( "arm",New TIntType, New TConstExpr.Create( New TIntType, Int(opt_arch="arm" Or opt_arch="armeabi" Or opt_arch="armeabiv7a" Or opt_arch="arm64v8a" ) ),0 )
+	env.InsertDecl New TConstDecl.Create( "armeabi",New TIntType, New TConstExpr.Create( New TIntType, Int(opt_arch="armeabi" ) ),0 )
+	env.InsertDecl New TConstDecl.Create( "armeabiv7a",New TIntType, New TConstExpr.Create( New TIntType, Int(opt_arch="armeabiv7a" ) ),0 )
+	env.InsertDecl New TConstDecl.Create( "arm64v8a",New TIntType, New TConstExpr.Create( New TIntType, Int(opt_arch="arm64v8a" ) ),0 )
+	env.InsertDecl New TConstDecl.Create( "js",New TIntType, New TConstExpr.Create( New TIntType, Int(opt_arch="js" ) ),0 )
 
 	' endian
-	env.InsertDecl New TConstDecl.Create( "bigendian",New TIntType,New TConstExpr.Create( New TIntType,opt_arch="ppc" ),0 )
-	env.InsertDecl New TConstDecl.Create( "littleendian",New TIntType,New TConstExpr.Create( New TIntType,opt_arch<>"ppc" ),0 )
+	env.InsertDecl New TConstDecl.Create( "bigendian",New TIntType, New TConstExpr.Create( New TIntType, Int(opt_arch="ppc" ) ),0 )
+	env.InsertDecl New TConstDecl.Create( "littleendian",New TIntType, New TConstExpr.Create( New TIntType, Int(opt_arch<>"ppc" ) ),0 )
 
 	' opengles target platform
-	env.InsertDecl New TConstDecl.Create( "opengles",New TIntType,New TConstExpr.Create( New TIntType, opt_platform="android" Or opt_platform="raspberrypi" Or opt_platform="emscripten" ),0 )
+	env.InsertDecl New TConstDecl.Create( "opengles",New TIntType, New TConstExpr.Create( New TIntType, Int( opt_platform="android" Or opt_platform="raspberrypi" Or opt_platform="emscripten" ) ),0 )
 
 	' new compiler
-	env.InsertDecl New TConstDecl.Create( "bmxng",New TIntType,New TConstExpr.Create( New TIntType, True ),0 )
+	env.InsertDecl New TConstDecl.Create( "bmxng",New TIntType, New TConstExpr.Create( New TIntType, Int( True ) ),0 )
 
 '	env.InsertDecl New TConstDecl.Create( "LANG",TType.stringType,New TConstExpr.Create( TType.stringType,ENV_LANG ),0 )
 '	env.InsertDecl New TConstDecl.Create( "TARGET",TType.stringType,New TConstExpr.Create( TType.stringType,ENV_TARGET ),0 )


### PR DESCRIPTION
Latest commits disabled auto-casts for certain types. This made
`TConstExpr.Create( New TIntType, opt_platform="linux" )`
fail.

This patch adjusts the lines in BCC using the "autocast" approach.