### PR TITLE
[ifc] Interface Implementation

### DIFF
--- a/ctranslator.bmx
+++ b/ctranslator.bmx
@@ -741,7 +741,7 @@ t:+"NULLNULLNULL"
 						If decl.scope.IsExtern()
 							Return decl.munged + Bra(TransArgs( args,decl, TransSubExpr( lhs ) ))
 						Else
-							If cdecl.IsInterface() And reserved_methods.Find("," + decl.ident.ToLower() + ",") = -1 Then
+							If cdecl.IsInterface() And reserved_methods.Find("," + decl.IdentLower() + ",") = -1 Then
 								Local ifc:String = Bra("(struct " + cdecl.munged + "_methods*)" + Bra("bbObjectInterface(" + TransSubExpr( lhs ) + ", " + "&" + cdecl.munged + "_ifc)"))
 								Return ifc + "->" + TransFuncPrefix(cdecl, decl) + decl.ident+TransArgs( args,decl, TransSubExpr( lhs ) )
 							Else
@@ -760,7 +760,7 @@ t:+"NULLNULLNULL"
 					If decl.attrs & FUNC_PTR Then
 						Return "(" + obj + TransSubExpr( lhs ) + ")->" + decl.munged+TransArgs( args,decl, Null)
 					Else
-						If cdecl.IsInterface() And reserved_methods.Find("," + decl.ident.ToLower() + ",") = -1 Then
+						If cdecl.IsInterface() And reserved_methods.Find("," + decl.IdentLower() + ",") = -1 Then
 							Local ifc:String = Bra("(struct " + cdecl.munged + "_methods*)" + Bra("bbObjectInterface(" + obj + TransSubExpr( lhs ) + ", " + "&" + cdecl.munged + "_ifc)"))
 							Return ifc + "->" + TransFuncPrefix(cdecl, decl) + decl.ident+TransArgs( args,decl, TransSubExpr( lhs ) )
 						Else

--- a/decl.bmx
+++ b/decl.bmx
@@ -1580,7 +1580,7 @@ End Rem
 
 				For Local i:Int = 0 Until funcs.length
 					' found a match - we are overriding it
-					If func.ident.ToLower() = funcs[i].ident.ToLower() Then
+					If func.IdentLower() = funcs[i].IdentLower() Then
 						matched = True
 						Exit
 					End If
@@ -1867,7 +1867,7 @@ End Rem
 						If decl.IsAbstract()
 							Local found:Int
 							For Local decl2:TFuncDecl=EachIn impls
-								If decl.ident.ToLower() = decl2.ident.ToLower() And decl2.EqualsFunc( decl )
+								If decl.IdentLower() = decl2.IdentLower() And decl2.EqualsFunc( decl )
 									found=True
 									Exit
 								EndIf

--- a/expr.bmx
+++ b/expr.bmx
@@ -1143,6 +1143,11 @@ Type TCastExpr Extends TExpr
 			Return Self
 		End If
 
+		If TObjectType(ty) And TObjectType(src) And TObjectType(src).classdecl.IsInterface() And flags & CAST_EXPLICIT Then
+			exprType = ty
+			Return Self
+		End If
+
 		If Not exprType
 			Err "Unable to convert from "+src.ToString()+" to "+ty.ToString()+"."
 		EndIf

--- a/iparser.bmx
+++ b/iparser.bmx
@@ -261,6 +261,8 @@ Type TIParser
 							class.attrs :| DECL_ABSTRACT | DECL_FINAL
 						Else If CParse("E")
 							class.attrs :| DECL_EXTERN
+						Else If CParse("AI")
+							class.attrs :| CLASS_INTERFACE | DECL_ABSTRACT
 						End If
 'DebugStop
 						If CParse( "=" )
@@ -425,7 +427,18 @@ Type TIParser
 		Else
 			superTy = New TIdentType.Create( "brl.classes.object" )
 		EndIf
-'DebugStop
+
+		' implements
+		If CParse("@") Then
+			Local nimps:Int
+			Repeat
+				If imps.Length=nimps imps=imps + New TIdentType[10]
+				imps[nimps]=ParseIdentType()
+				nimps:+1
+			Until Not CParse(",")
+			imps=imps[..nimps]
+		End If
+		
 		Local classDecl:TClassDecl=New TClassDecl.Create( id,args,superTy,imps,attrs )
 		
 		If classDecl.IsExtern()
@@ -727,7 +740,7 @@ Type TIParser
 			args=args[..nargs]
 		EndIf
 		Parse ")"
-		
+
 		Repeat		
 			If CParse( "F" )
 				attrs:|DECL_FINAL

--- a/options.bmx
+++ b/options.bmx
@@ -25,7 +25,7 @@ SuperStrict
 
 Import "base.configmap.bmx"
 
-Const version:String = "0.58"
+Const version:String = "0.59"
 
 Const BUILDTYPE_APP:Int = 0
 Const BUILDTYPE_MODULE:Int = 1

--- a/parser.bmx
+++ b/parser.bmx
@@ -2794,7 +2794,21 @@ End Rem
 		Repeat
 			SkipEols
 			Select _toke
-			Case "end", "endtype"
+			Case "end"
+				NextToke
+				Exit
+			Case "endtype"
+				If attrs & CLASS_INTERFACE Then
+					Err "Syntax error - expecting End Interface, not 'EndType'"
+				End If
+				toke = Null
+				NextToke
+				Exit
+			Case "endinterface"
+				If Not (attrs & CLASS_INTERFACE) Then
+					Err "Syntax error - expecting End Type, not 'EndInterface'"
+				End If
+				toke = Null
 				NextToke
 				Exit
 			Case "private"
@@ -2825,7 +2839,7 @@ End Rem
 			End Select
 		Forever
 
-		If toke CParse toke
+		If toke Parse toke
 
 		Return classDecl
 	End Method

--- a/parser.bmx
+++ b/parser.bmx
@@ -2706,7 +2706,7 @@ End Rem
 				superTy=New TIdentType.Create( "brl.classes.object" )
 			End If
 		EndIf
-Rem
+
 		If CParse( "implements" )
 
 			If attrs & DECL_EXTERN
@@ -2717,9 +2717,9 @@ Rem
 				Err "Implements cannot be used with interfaces."
 			EndIf
 
-			If attrs & CLASS_TEMPLATEARG
-				Err "Implements cannot be used with class parameters."
-			EndIf
+			'If attrs & CLASS_TEMPLATEARG
+			'	Err "Implements cannot be used with class parameters."
+			'EndIf
 
 			Local nimps:Int
 			Repeat
@@ -2729,14 +2729,22 @@ Rem
 			Until Not CParse(",")
 			imps=imps[..nimps]
 		EndIf
-End Rem
+
 		Repeat
 			If CParse( "final" )
 
 				If attrs & CLASS_INTERFACE
 					Err "Final cannot be used with interfaces."
-				EndIf
+				End If
+				
+				If attrs & DECL_FINAL
+					Err "Duplicate type attribute."
+				End If
 
+				If attrs & DECL_ABSTRACT
+					Err "Classes cannot be both final and abstract."
+				End If
+				
 				attrs:|DECL_FINAL
 
 			Else If CParse( "abstract" )
@@ -2744,6 +2752,14 @@ End Rem
 				If attrs & CLASS_INTERFACE
 					Err "Abstract cannot be used with interfaces."
 				EndIf
+				
+				If attrs & DECL_ABSTRACT
+					Err "Duplicate type attribute."
+				End If
+				
+				If attrs & DECL_FINAL
+					Err "Types cannot be both final and abstract."
+				End If
 
 				attrs:|DECL_ABSTRACT
 			Else
@@ -2753,9 +2769,6 @@ End Rem
 
 		'check for metadata
 		If CParse( "{" )
-			' TODO : do something with the metadata
-			'metadata for "type"s
-			'print "meta for type: "+id+ " -> "+ParseMetaData()
 			meta = ParseMetaData()
 		End If
 
@@ -2777,7 +2790,7 @@ End Rem
 
 		Local method_attrs:Int=decl_attrs|FUNC_METHOD | (attrs & DECL_NODEBUG)
 		If attrs & CLASS_INTERFACE method_attrs:|DECL_ABSTRACT
-
+		
 		Repeat
 			SkipEols
 			Select _toke
@@ -2800,7 +2813,7 @@ End Rem
 				If decl.IsCtor() decl.retTypeExpr=New TObjectType.Create( classDecl )
 				classDecl.InsertDecl decl
 			Case "function"
-				If (attrs & CLASS_INTERFACE) And _toke<>"const"
+				If (attrs & CLASS_INTERFACE)
 					Err "Interfaces can only contain constants and methods."
 				EndIf
 				Local decl:TFuncDecl=ParseFuncDecl( _toke,decl_attrs )
@@ -3173,8 +3186,8 @@ End Rem
 				Next
 			Case "type"
 				_module.InsertDecl ParseClassDecl( _toke,attrs )
-			'Case "interface"
-			'	_module.InsertDecl ParseClassDecl( _toke,attrs|CLASS_INTERFACE|DECL_ABSTRACT )
+			Case "interface"
+				_module.InsertDecl ParseClassDecl( _toke,attrs|CLASS_INTERFACE|DECL_ABSTRACT )
 			Case "function"
 				_module.InsertDecl ParseFuncDecl( _toke,attrs )
 			Case "rem"

--- a/toker.bmx
+++ b/toker.bmx
@@ -53,7 +53,8 @@ Type TToker
 	"and;or;shl;shr;sar;end;if;then;else;elseif;endif;while;wend;repeat;until;forever;"+ ..
 	"for;to;step;next;return;"+ ..
 	"alias;rem;endrem;throw;assert;try;catch;nodebug;incbin;"+ ..
-	"endselect;endmethod;endfunction;endtype;endextern;endtry;pi;release;defdata;readdata;restoredata;"
+	"endselect;endmethod;endfunction;endtype;endextern;endtry;pi;release;defdata;readdata;restoredata;" + ..
+	"interface;implements;"
 
 	Global _symbols$[]=[ "..","[]",":*",":/",":+",":-",":|",":&",":~~",":shr",":shl",":sar",":mod" ]
 	Global _symbols_map$[]=[ "..","[]","*=","/=","+=","-=","|=","&=","^=",">>=", "<<=",">>=","%=" ]

--- a/toker.bmx
+++ b/toker.bmx
@@ -54,7 +54,7 @@ Type TToker
 	"for;to;step;next;return;"+ ..
 	"alias;rem;endrem;throw;assert;try;catch;nodebug;incbin;"+ ..
 	"endselect;endmethod;endfunction;endtype;endextern;endtry;pi;release;defdata;readdata;restoredata;" + ..
-	"interface;implements;"
+	"interface;endinterface;implements;"
 
 	Global _symbols$[]=[ "..","[]",":*",":/",":+",":-",":|",":&",":~~",":shr",":shl",":sar",":mod" ]
 	Global _symbols_map$[]=[ "..","[]","*=","/=","+=","-=","|=","&=","^=",">>=", "<<=",">>=","%=" ]


### PR DESCRIPTION
Adds Interfaces to BlitzMax.

Interfaces can be created using the following :
```blitzmax
Interface myInterface
  Method myMethod()
End Interface

Type myType Implements myInterface
  Method myMethod()
    ' implement here
  End Method
End Type
````

Interfaces can be extend other interfaces :
```blitzmax
Interface myOtherInterface Extends myInterface
  Method anotherMethod()
End Interface
```

Types can implement multiple interfaces :
```blitzmax
Type myBigType Implements myInterface, anotherInterface
  Method myMethod()
  End Method

  Method moreMethod()
  End Method
End Type
```

Abstract types which implement an interface can elect not to implement those methods. Its concrete subclass however, will need to implement any methods in the hierarchy that haven't.