### PR TITLE
Enhance "Overriding method does not match any overridden method"-output.

### DIFF
--- a/decl.bmx
+++ b/decl.bmx
@@ -1291,14 +1291,17 @@ Type TFuncDecl Extends TBlockDecl
 								errorDetails :+ "Return type is ~q"+retType.ToString()+"~q, expected ~q"+decl.retType.ToString()+"~q. "
 							End If
 
-							If argDecls.Length<>decl.argDecls.Length
-								errorDetails :+ "Argument count differs. "
+							If argDecls.Length <> decl.argDecls.Length
+								errorDetails :+ "Argument count differs. Got " + argDecls.Length +", expected " + decl.argDecls.Length + " arguments."
 							End If
-							For Local i:Int=0 Until argDecls.Length
-								If Not argDecls[i].ty.EqualsType( decl.argDecls[i].ty )
-									errorDetails :+ "Argument #"+(i+1)+" is ~q" + argDecls[i].ty.ToString()+"~q, expected ~q"+decl.argDecls[i].ty.ToString()+"~q. "
-								End If
-							Next
+							local argCount:int = Min(argDecls.Length, decl.argDecls.Length)
+							if argCount > 0
+								For Local i:Int=0 Until argCount
+									If Not argDecls[i].ty.EqualsType( decl.argDecls[i].ty )
+										errorDetails :+ "Argument #"+(i+1)+" is ~q" + argDecls[i].ty.ToString()+"~q, expected ~q"+decl.argDecls[i].ty.ToString()+"~q. "
+									End If
+								Next
+							endif
 							'remove last space
 							errorDetails = errorDetails.Trim()
 						EndIf

--- a/decl.bmx
+++ b/decl.bmx
@@ -1252,6 +1252,7 @@ Type TFuncDecl Extends TBlockDecl
 'DebugStop
 'DebugLog ident + "..."
 			While sclass
+				local errorDetails:String = ""
 'DebugLog "Checking Class : " + sclass.ident
 				Local found:Int
 				For Local decl:TFuncDecl=EachIn sclass.FuncDecls( )
@@ -1284,11 +1285,27 @@ Type TFuncDecl Extends TBlockDecl
 						'	EndIf
 						'	munged=overrides.munged
 						'EndIf
+						Else
+							'prepare a more detailed error message
+							If (not retType.EqualsType( decl.retType ) or not retType.ExtendsType( decl.retType )) Or (decl.retType and not decl.retType.EqualsType( retType ))
+								errorDetails :+ "Return type is ~q"+retType.ToString()+"~q, expected ~q"+decl.retType.ToString()+"~q. "
+							End If
+
+							If argDecls.Length<>decl.argDecls.Length
+								errorDetails :+ "Argument count differs. "
+							End If
+							For Local i:Int=0 Until argDecls.Length
+								If Not argDecls[i].ty.EqualsType( decl.argDecls[i].ty )
+									errorDetails :+ "Argument #"+(i+1)+" is ~q" + argDecls[i].ty.ToString()+"~q, expected ~q"+decl.argDecls[i].ty.ToString()+"~q. "
+								End If
+							Next
+							'remove last space
+							errorDetails = errorDetails.Trim()
 						EndIf
 					End If
 				Next
 				If found
-					If Not overrides Err "Overriding method does not match any overridden method."
+					If Not overrides Err "Overriding method does not match any overridden method. (Detail: " + errorDetails+")"
 					' for overrides, make the ident match that of the superclass
 					ident = overrides.ident
 					


### PR DESCRIPTION
Output now contains details of what return-type/param-type was expected and which kind was provided.