### PR TITLE
Fix: TArgDecl does not need "Local "-prefix in ToString().

### DIFF
--- a/decl.bmx
+++ b/decl.bmx
@@ -491,9 +491,13 @@ Type TLocalDecl Extends TVarDecl
 	Method OnCopy:TDecl(deep:Int = True)
 		Return New TLocalDecl.Create( ident,ty,CopyInit(),attrs, generated )
 	End Method
+
+	Method GetDeclPrefix:string()
+		return "Local "
+	End Method
 	
 	Method ToString$()
-		Return "Local "+Super.ToString()
+		Return GetDeclPrefix() + Super.ToString()
 	End Method
 
 End Type
@@ -524,6 +528,10 @@ Type TArgDecl Extends TLocalDecl
 		d.ty = d.declTy
 		d.init = d.declInit
 		Return d
+	End Method
+
+	Method GetDeclPrefix:string()
+		return ""
 	End Method
 	
 	Method ToString$()


### PR DESCRIPTION
Fixes bmx-ng/bcc#184

That `ToString()` in `TArgDecl` could get removed too (as it just `return Super.ToString()`). As other Decl-types do not contain a `ToString()` (and therefor rely on the parental one) I do not see a reason to keep it ... but am leaving this as homework or for another little commit