### PR TITLE
Proper support for function pointers (fix for issue #211)

### DIFF
--- a/ctranslator.bmx
+++ b/ctranslator.bmx
@@ -958,7 +958,9 @@ t:+"NULLNULLNULL"
 
 					If decl.attrs & FUNC_PTR Then
 						'Return "(" + obj + TransSubExpr( lhs ) + ")->" + decl.munged+TransArgs( args,decl, Null)
-						Return TransSubExpr( lhs ) + "->" + decl.munged+TransArgs( args,decl, Null)
+					Local op:String
+						If cdecl.IsStruct() Then op = "." Else op = "->"
+						Return TransSubExpr( lhs ) + op + decl.munged+TransArgs( args,decl, Null)
 					Else
 						'Local lvar:String = CreateLocal(lhs, False)
 						'Local lvarInit:String = Bra(lvar + " = " + lhs.Trans())
@@ -1161,7 +1163,9 @@ t:+"NULLNULLNULL"
 					End If
 
 					If decl.attrs & FUNC_PTR Then
-						Return lhs.Trans() + "->" + decl.munged+TransArgs( args,decl, Null)
+						Local op:String
+						If cdecl.IsStruct() Then op = "." Else op = "->"
+						Return lhs.Trans() + op + decl.munged+TransArgs( args,decl, Null)
 					Else
 						If decl.scope.IsExtern()
 							'Local cdecl:TClassDecl = TClassDecl(decl.scope)
@@ -4527,7 +4531,8 @@ End Rem
 'DebugStop
 		Local ind:String = "->"
 		If decl.scope And TClassDecl(decl.scope) And TClassDecl(decl.scope).IsStruct() Then
-			If exprType And Not IsPointerType(exprType) And variable <> "o" Then
+			Local exprIsStruct:Int = TObjectType(exprType) And TObjectType(exprType).classDecl.attrs & CLASS_STRUCT
+			If exprType And (exprIsStruct Or Not IsPointerType(exprType)) And variable <> "o" Then
 				ind = "."
 			End If
 		End If

--- a/expr.bmx
+++ b/expr.bmx
@@ -691,8 +691,12 @@ Type TInvokeExpr Extends TExpr
 		'	exprType=decl.retType
 		'End If
 
-		If ((isArg Or isRhs) And Not invokedWithBraces) And (args = Null Or args.length = 0) Then
-			' nothing to do here, as we are probably a function pointer. i.e. no braces and no 
+		'If ((isArg Or isRhs) And Not invokedWithBraces) And (args = Null Or args.length = 0) Then
+
+		' if the call was a statement (even one written without parentheses), then invokedWithBraces is true
+		' so no complicated checks are needed here; if invokedWithBraces is false, this is definitely not a call
+		If Not invokedWithBraces Then
+			' nothing to do here, as we are a function pointer. i.e. no braces
 			' and our expression type is a function ptr...
 			exprType = New TFunctionPtrType.Create(decl)
 			
@@ -1323,9 +1327,11 @@ Type TCastExpr Extends TExpr
 				End If
 			Else
 				' return type should be function ptr?
-				' TODO
-				exprType = ty
-				Return expr
+				Local retType:TType = expr.exprType
+				If TFunctionPtrType(retType) And TFunctionPtrType(ty).func.EqualsFunc(TFunctionPtrType(retType).func) Then
+					exprType = retType
+					Return expr
+				End If
 			End If
 		End If
 

--- a/translator.bmx
+++ b/translator.bmx
@@ -886,12 +886,16 @@ End Rem
 		If Not decl.munged Then
 			MungDecl decl
 		End If
-
-		If (decl.attrs & FUNC_PTR) And (decl.attrs & FUNC_INIT) And Not expr.InvokedWithBraces Return decl.munged
 		
-		If ((decl.attrs & FUNC_PTR) Or (expr.decl.attrs & FUNC_PTR)) And Not expr.InvokedWithBraces Return decl.munged
+		'If (decl.attrs & FUNC_PTR) And (decl.attrs & FUNC_INIT) And Not expr.InvokedWithBraces Return decl.munged
 		
-		If Not expr.InvokedWithBraces And expr.IsRhs Return decl.munged
+		'If ((decl.attrs & FUNC_PTR) Or (expr.decl.attrs & FUNC_PTR)) And Not expr.InvokedWithBraces Return decl.munged
+		
+		'If Not expr.InvokedWithBraces And expr.IsRhs Return decl.munged
+		
+		' if the call was a statement (even one written without parentheses), then invokedWithBraces is true
+		' so no complicated checks are needed here; if invokedWithBraces is false, this is definitely not a call
+		If Not expr.InvokedWithBraces Then Return decl.munged
 		
 		If decl.munged.StartsWith( "$" ) Return TransIntrinsicExpr( decl,Null,expr.args )
 		

--- a/type.bmx
+++ b/type.bmx
@@ -1742,10 +1742,10 @@ Type TFunctionPtrType Extends TType
 	Method EqualsType:Int( ty:TType )
 		If Not TFunctionPtrType(ty) Then Return False
 		Local tyfunc:TFuncDecl = TFunctionPtrType(ty).func
-		If Not func.retType.EqualsType(tyfunc.retType) Then Return False
-		If Not (func.argDecls.Length = tyfunc.argDecls.Length) Then Return False
+		If Not tyfunc.retType.EqualsType(func.retType) Then Return False
+		If Not (tyfunc.argDecls.Length = func.argDecls.Length) Then Return False
 		For Local a:Int = 0 Until func.argDecls.Length
-			If Not func.argDecls[a].ty.EqualsType(tyfunc.argDecls[a].ty) Then Return False
+			If Not tyfunc.argDecls[a].ty.EqualsType(func.argDecls[a].ty) Then Return False
 		Next
 		Return True
 	End Method

--- a/type.bmx
+++ b/type.bmx
@@ -1740,8 +1740,14 @@ Type TFunctionPtrType Extends TType
 	End Method
 
 	Method EqualsType:Int( ty:TType )
-' TODO : compare function decl
-		Return TFunctionPtrType( ty )<>Null
+		If Not TFunctionPtrType(ty) Then Return False
+		Local tyfunc:TFuncDecl = TFunctionPtrType(ty).func
+		If Not func.retType.EqualsType(tyfunc.retType) Then Return False
+		If Not (func.argDecls.Length = tyfunc.argDecls.Length) Then Return False
+		For Local a:Int = 0 Until func.argDecls.Length
+			If Not func.argDecls[a].ty.EqualsType(tyfunc.argDecls[a].ty) Then Return False
+		Next
+		Return True
 	End Method
 	
 	Method ExtendsType:Int( ty:TType, noExtendString:Int = False, widensTest:Int = False )


### PR DESCRIPTION
- fixed parsing for declarations of function pointer variables and for functions returning functions
- fixed C generation for function pointer types
- fixed function pointers in expressions being mistaken for calls


(_There is one remaining bug which I've just discovered and not figured out how to fix, see below_)

**In detail:**

I added a new helper function named ParseFuncParamDecl, which parses one pair of parentheses with a parameter list in it and returns an array of TArgDecl. ParseDeclType now uses this to parse array and function pointer types (nested into each other to any degree) like any other type. This simplifies ParseFuncDecl, which can now just use the result of ParseDeclType without doing extra work to parse the parameter list.
Further changes were needed to get the C translator to properly generate function pointer declarations, and to stop function pointers from being falsely evaluated as calls; I left a few comments in the code regarding that.

Note that these changes neccessitate a fix in BRL.Reflection:
The method EnumFunctions currently contains the following code:
```
		Function compareFunction:Int( a:TFunction, b:TFunction)
			Return a.Name().Compare(b.Name())
		EndFunction
		
		[...]
		
		list.Sort( True, compareFunction)
```
This will not actually compile anymore (it's not allowed in vanilla either, but it slipped under the radar in NG so far). TList.Sort expects a parameter of type Int(Object, Object), not Int(TFunction, TFunction).
There are two ways to fix this:
- Define compareFunction with Object parameters and check for the correct type inside the function.
- Pass compareFunction to Sort as a Byte Ptr, forcing a cast from one function type to the other. This is kinda dirty however, and it might be dangerous in case the list already contains non-TFunction elements before it is passed to EnumFunctions.

Anyway, function pointers should now work properly in NG. Here are some samples that I tested, which now all compile and run fine:
```
SuperStrict
Framework BRL.StandardIO

Local func(str:String) = Print
func "hi"
```
```
SuperStrict
Framework BRL.StandardIO

Local funcprovider()() = GetFunc
funcprovider()()

Function GetFunc()()
    Return Func
	
	Function Func()
		Print "yay"
	End Function
End Function
```
```
SuperStrict
Framework BRL.StandardIO

Local f(i:Int Var) = Inc
Local x:Int = 3
f x	' no problems with Var parameters
Print x

Function Inc(i:Int Var)
	i :+ 1
End Function
```
```
SuperStrict
Framework BRL.StandardIO

Do
Input ""

Function Do(F(s:String) = Print, s:String = "hello")	' functions can be used as parameter defaults
	F s
End Function
```
```
SuperStrict
Framework BRL.StandardIO

CallAllTheseFunctions([A, B, C])
Input ""

Function CallAllTheseFunctions(array()[])
    For Local func() = EachIn array
        func
    Next
EndFunction

Function A() Print "A" End Function
Function B() Print "B" End Function
Function C() Print "C" End Function
```
```
SuperStrict
Framework BRL.StandardIO

Local ap:Byte Ptr = A
Local funcptr:Byte Ptr Ptr = Varptr ap
Local func() = funcptr[0]	' casting to and from pointers works fine
func
Input ""

Function A() Print "A" End Function
```
```
SuperStrict
Framework BRL.StandardIO

Local f(x:Int = 4) = A	' Vanilla doesn't actually allow specifying parameter defaults for function pointer variables, but it works in NG now, so why not!
f
f 5
Input ""

Function A(i:Int = 3) Print "A"+i End Function
```
And finally, the one example that doesn't quite work:
```
SuperStrict
Framework BRL.StandardIO

Local i:Int = GetArrayOfThreeTimesMakeArray()[2](5).Length
Print i

Function MakeArray:String[](size:Int)
	Return New String[size]
End Function

Function GetArrayOfThreeTimesMakeArray:String[](size:Int)[]()
	Local r:String[](size:Int)[] = [MakeArray, MakeArray, MakeArray]
	Return r
End Function
```
This should print 5, but compilation fails with an internal error. I haven't figured out why this happens, but the autoarray is at fault. The problem doesn't occur if one first stores MakeArray in an extra variable like so:
```
	Local ma:String[](size:Int) = MakeArray
	Local r:String[](size:Int)[] = [ma, ma, ma]
```
