### PR TITLE
Skip empty metatags

### DIFF
--- a/parser.bmx
+++ b/parser.bmx
@@ -2553,7 +2553,9 @@ End Rem
 		SkipEols
 
 		Repeat
-			
+			'reached end of meta data declaration
+			If _toke="}" Then Exit
+
 			If meta.metadataString Then
 				meta.metadataString :+ " "
 			End If
@@ -2595,9 +2597,6 @@ End Rem
 			End If
 			
 			meta.InsertMeta(key.ToLower(), value)
-			
-			'reached end of meta data declaration
-			If _toke="}" Then Exit
 		Forever
 
 		'continue to next token


### PR DESCRIPTION
Before: check for closing curly bracket was done after at least one character was processed
Now: Check is skipped if next (non-space) character is already the closing curly bracket

Closes bmx-ng/bcc/#253