### PR TITLE
Variance for function pointer types

### DIFF
--- a/decl.bmx
+++ b/decl.bmx
@@ -1285,7 +1285,7 @@ End Rem
 					exact = False
 					Continue
 				End If
-										
+
 				For Local i:Int=0 Until argDecls.Length
 	
 					If i<argExprs.Length And argExprs[i]
@@ -1661,15 +1661,15 @@ Type TFuncDecl Extends TBlockDecl
 		Return (attrs & FUNC_PROPERTY)<>0
 	End Method
 	
-	Method EqualsArgs:Int( decl:TFuncDecl )
+	Method EqualsArgs:Int( decl:TFuncDecl ) ' careful, this is not commutative!
 		If argDecls.Length<>decl.argDecls.Length Return False
 		For Local i:Int=0 Until argDecls.Length
-			If Not argDecls[i].ty.EqualsType( decl.argDecls[i].ty ) And Not argDecls[i].ty.ExtendsType( decl.argDecls[i].ty ) Return False
+			If Not decl.argDecls[i].ty.EqualsType( argDecls[i].ty ) Return False
 		Next
 		Return True
 	End Method
 
-	Method EqualsFunc:Int( decl:TFuncDecl )
+	Method EqualsFunc:Int( decl:TFuncDecl ) ' careful, this is not commutative!
 		If IsCtor() Then
 			Return EqualsArgs( decl )
 		Else

--- a/decl.bmx
+++ b/decl.bmx
@@ -1664,7 +1664,7 @@ Type TFuncDecl Extends TBlockDecl
 	Method EqualsArgs:Int( decl:TFuncDecl ) ' careful, this is not commutative!
 		If argDecls.Length<>decl.argDecls.Length Return False
 		For Local i:Int=0 Until argDecls.Length
-			If Not decl.argDecls[i].ty.EqualsType( argDecls[i].ty ) Return False
+			If Not decl.argDecls[i].ty.EqualsType( argDecls[i].ty ) And Not decl.argDecls[i].ty.ExtendsType( argDecls[i].ty ) Return False
 		Next
 		Return True
 	End Method

--- a/type.bmx
+++ b/type.bmx
@@ -1759,8 +1759,8 @@ Type TFunctionPtrType Extends TType
 			If Not func.retType.ExtendsType(tyfunc.retType) Then Return False
 			If Not (func.argDecls.Length = tyfunc.argDecls.Length) Then Return False
 			For Local a:Int = 0 Until func.argDecls.Length
-				' does our arg equal declared arg?
-				If Not func.argDecls[a].ty.EqualsType(tyfunc.argDecls[a].ty) Then Return False
+				' does declared arg extend our arg?
+				If Not tyfunc.argDecls[a].ty.ExtendsType(func.argDecls[a].ty) Then Return False
 			Next
 			Return True
 		EndIf

--- a/type.bmx
+++ b/type.bmx
@@ -1756,11 +1756,11 @@ Type TFunctionPtrType Extends TType
 		If TFunctionPtrType( ty )
 			' declared function pointer
 			Local tyfunc:TFuncDecl = TFunctionPtrType(ty).func
-			If Not tyfunc.retType.EqualsType(func.retType) Then Return False
-			If Not (tyfunc.argDecls.Length = func.argDecls.Length) Then Return False
+			If Not func.retType.ExtendsType(tyfunc.retType) Then Return False
+			If Not (func.argDecls.Length = tyfunc.argDecls.Length) Then Return False
 			For Local a:Int = 0 Until func.argDecls.Length
-				' does our arg extend declared arg?
-				If Not func.argDecls[a].ty.ExtendsType(tyfunc.argDecls[a].ty) Then Return False
+				' does our arg equal declared arg?
+				If Not func.argDecls[a].ty.EqualsType(tyfunc.argDecls[a].ty) Then Return False
 			Next
 			Return True
 		EndIf


### PR DESCRIPTION
Allows function pointer variables to accept functions that do not exactly match the declared type of the variable.
They now accept functions with a more derived return type than declared (first commit, as a fix for issue #258) as well as less derived parameter types (second commit, as a "bonus feature" discussed in #258).