### PR TITLE
Index operator overloading

### DIFF
--- a/expr.bmx
+++ b/expr.bmx
@@ -1513,7 +1513,7 @@ Type TCastExpr Extends TExpr
 		If TVarPtrType(ty) Then
 			If Not TVarExpr(expr) And Not TMemberVarExpr(expr) And Not (TStmtExpr(expr) And TIndexExpr(TStmtExpr(expr).expr)) Then
 				If Not TIndexExpr(expr) Or (TIndexExpr(expr) And Not TVarExpr(TIndexExpr(expr).expr) And Not TMemberVarExpr(TIndexExpr(expr).expr))  Then
-					Err "Subexpression for 'Ptr' must be a variable"
+					Err "Subexpression for 'Varptr' must be a variable or an element of an array, pointer or string"
 				End If
 			End If
 			exprType = src.Copy()

--- a/expr.bmx
+++ b/expr.bmx
@@ -1661,7 +1661,7 @@ Type TUnaryExpr Extends TExpr
 				If error.StartsWith("Compile Error") Then
 					Throw error
 				Else
-					Err "Operator " + op + " cannot be used with Objects."
+					Err "Operator " + op + " is not defined for type '" + expr.exprType.ToString() + "'"
 				End If
 			End Try
 		End If
@@ -1775,7 +1775,7 @@ Type TBinaryMathExpr Extends TBinaryExpr
 				If error.StartsWith("Compile Error") Then
 					Throw error
 				Else
-					Err "Operator " + op + " cannot be used with Objects."
+					Err "Operator " + op + " is not defined between types '" + lhs.exprType.ToString() + "' and '" + rhs.exprType.ToString() + "'"
 				End If
 			End Try
 		End If

--- a/parser.bmx
+++ b/parser.bmx
@@ -2684,8 +2684,11 @@ End Rem
 						id = t
 					Case ":mod", ":shl", ":shr"
 						id = t
+					Case "[]"
+						If CParse("=") Then t :+ "="
+						id = t
 					Default
-						DoErr "Operator must be one of: * / + - & | ~~ :* :/ :+ :- :& :| :~~ < > <= >= = <> mod shl shr :mod :shl :shr"
+						DoErr "Operator must be one of: * / + - & | ~~ :* :/ :+ :- :& :| :~~ < > <= >= = <> mod shl shr :mod :shl :shr [] []="
 				End Select
 				ty=ParseDeclType()
 			Else

--- a/translator.bmx
+++ b/translator.bmx
@@ -453,6 +453,10 @@ Type TTranslator
 				Return "_shleq"
 			Case ":shr"
 				Return "_shreq"
+			Case "[]"
+				Return "_iget"
+			Case "[]="
+				Return "_iset"
 		End Select
 		Err "?? unknown symbol ?? : " + sym
 	End Method


### PR DESCRIPTION
I figured it would make sense to add index operator overloading to BlitzMax. This feature allows user-defined types to support indexed element access via brackets (`[]`), just like the built-in arrays, pointers and strings do.
Like all operator overloading, it should be used conservatively, but this should be a useful addition for collection types such as arrays, lists or maps.

This pull request adds two new overloadable operators: 

- `Method Operator []` is the index operator. It should take one or more *indices* as parameters and return the corresponding *element*.
- `Method Operator []=` is the index assignment operator. It should take one or more *indices* and the to-be-assigned *element* as parameters and not return anything.

<br>

As an example, a wrapper type for an array that automatically grows when accessing an out-of-bounds index can be written like this:
```BlitzMax
SuperStrict
Framework BRL.StandardIO

Type TDynamicIntArray
	Private
	
	Field array:Int[]
	Field startIndex:Int = 0
	
	Public
	
	Method Operator [] :Int(index:Int)
		If index < startIndex Or index >= startIndex + array.length Then Return 0
		Return array[index - startIndex]
	End Method
	
	Method Operator []= (index:Int, value:Int)
		If index < startIndex Then
			array = array[index - startIndex..]
			startIndex = index
		Else If index >= startIndex + array.length Then
			array = array[..index - startIndex + 1]
		End If
		' ^ it's inefficient to grow arrays like this, but it's just a simple example
		array[index - startIndex] = value
	End Method
End Type


Local a:TDynamicIntArray = New TDynamicIntArray
a[-1] = -1 ' this calls Operator []=
a[2] = 2   ' this calls Operator []=
a[4] = 4   ' this calls Operator []=
For Local i:Int = -2 To 5
	Print i + ": " + a[i] ' this calls Operator []
Next
```

Indices can be of any type; they do not need to be `Int`:
```BlitzMax
SuperStrict
Framework BRL.StandardIO
Import BRL.Map

Type TMapWithOperators Extends TMap ' extending TMap to keep the example simple
	Method Operator [] :Object(key:Object)
		Return ValueForKey(key)
	End Method
	
	Method Operator []= (key:Object, value:Object)
		Insert key, value
	End Method
End Type

Local map:TMapWithOperators = New TMapWithOperators

' insert an element
map["hello"] = "world"

' retrieve the element
Print map["hello"].ToString()
```

And like the built-in multidimensional arrays, user-defined types can also support multiple indices:
```BlitzMax
SuperStrict
Framework BRL.StandardIO

Type TMultidimTest
	Method Operator [] :String(index0:Int, index1:Int, index2:Float)
		Return "Element at [" + index0 + ", " + index1 + ", " + index2 + "]"
	End Method
End Type

Local x:TMultidimTest = New TMultidimTest
Print x[1, 2, 3]
```

<br>

Limitations:
- Since user-defined operators are methods, elements of user-defined types cannot directly be used as `Var` or `Varptr` arguments (i.e. you cannot do `Varptr(x[y])`). This can be worked around by storing the element in a variable first.
- It is not yet possible to overload the slice operator (i.e. `array[3..5]`). I already have an idea how to do this though.