### PR TITLE
Error location parameter for InternalErr

### DIFF
--- a/config.bmx
+++ b/config.bmx
@@ -37,6 +37,7 @@ Const DEBUG:Int = False
 Const ABORT_ON_NULL:Int = True
 Const PROFILER:Int = False
 Const DEBUGSTOP_ON_ERROR:Int = False
+Const SHOW_INTERNALERR_LOCATION:Int = True
 
 Global ENV_LANG$
 
@@ -78,11 +79,13 @@ Function FormatError:String(path:String, line:Int, char:Int)
 	Return "[" + path + ";" + line + ";" + char + "]"
 End Function
 
-Function InternalErr()
+Function InternalErr(errorLocation:String)
 	If DEBUGSTOP_ON_ERROR Then
 		DebugStop ' useful for debugging!
 	End If
-	Throw "Compile Error. Internal Error : Please report the issue, with an example if possible, to https://github.com/bmx-ng/bcc/issues/new~n" + _errInfo + "~n"
+	Local locationMsg:String
+	If SHOW_INTERNALERR_LOCATION And errorLocation Then locationMsg = " in " + errorLocation
+	Throw "Compile Error: Internal Error" + locationMsg + ".~nPlease report the issue, with an example if possible, to https://github.com/bmx-ng/bcc/issues/new~n" + _errInfo + "~n"
 End Function
 
 Function IsSpace:Int( ch:Int )

--- a/ctranslator.bmx
+++ b/ctranslator.bmx
@@ -285,7 +285,7 @@ Type TCTranslator Extends TTranslator
 
 		If TExternObjectType( ty ) Return "struct " + TExternObjectType( ty ).classDecl.munged + p
 
-		InternalErr
+		InternalErr "TCTranslator.TransType"
 	End Method
 
 	Method TransIfcType$( ty:TType, isSuperStrict:Int = False )
@@ -363,7 +363,7 @@ Type TCTranslator Extends TTranslator
 			Return t
 		End If
 		If TExternObjectType( ty ) Return ":" + TExternObjectType(ty).classDecl.ident + p
-		InternalErr
+		InternalErr "TCTranslator.TransIfcType"
 	End Method
 
 	Method TransRefType$( ty:TType, ident:String )
@@ -448,7 +448,7 @@ Type TCTranslator Extends TTranslator
 			End If
 			If TFunctionPtrType( ty) Return "&brl_blitz_NullFunctionError" ' todo ??
 		EndIf
-		InternalErr
+		InternalErr "TCTranslator.TransValue"
 	End Method
 	
 	Method TransArgs$( args:TExpr[],decl:TFuncDecl, objParam:String = Null )
@@ -667,8 +667,7 @@ t:+"NULLNULLNULL"
 		End If
 
 		If Not TObjectType(ty) Or Not TObjectType(src) Then
-			DebugStop
-			InternalErr
+			InternalErr "TCTranslator.TransPtrCast"
 		End If
 
 		Local t$=TransType(ty, "TODO: TransPtrCast")
@@ -937,7 +936,7 @@ t:+"NULLNULLNULL"
 		Else If TBlockDecl(decl.scope)
 			Return decl.munged
 		EndIf
-		InternalErr
+		InternalErr "TCTranslator.TransStatic"
 	End Method
 
 	Method TransTemplateCast$( ty:TType,src:TType,expr$ )
@@ -1267,7 +1266,7 @@ t:+"NULLNULLNULL"
 						End If
 					End If
 				Else
-					InternalErr
+					InternalErr "TCTranslator.TransFunc"
 				End If
 				'Return TransSubExpr( lhs )+"->"+decl.munged+TransArgs( args,decl )
 				'Return decl.munged+TransArgs( args,decl, TransSubExpr( lhs ) )
@@ -1487,7 +1486,7 @@ t:+"NULLNULLNULL"
 			End If
 		End If
 
-		InternalErr
+		InternalErr "TCTranslator.TransSizeOfExpr"
 	End Method
 
 	'***** Expressions *****
@@ -2332,7 +2331,7 @@ t:+"NULLNULLNULL"
 		Case "pow" Return "(float)bbFloatPow"+Bra( arg0+","+arg1 )
 		'
 		End Select
-		InternalErr
+		InternalErr "TCTranslator.TransIntrinsicExpr"
 	End Method
 
 	'***** Statements *****
@@ -3613,9 +3612,9 @@ End Rem
 		If TObjectType( ty )
 
 			If id.EndsWith( ".p" )
-				If ty.GetClass().IsInterface() id=id[..-2] Else InternalErr
+				If ty.GetClass().IsInterface() id=id[..-2] Else InternalErr "TCTranslator.EmitMark"
 			Else
-				If ty.GetClass().IsInterface() InternalErr
+				If ty.GetClass().IsInterface() InternalErr "TCTranslator.EmitMark"
 			EndIf
 
 			If queue
@@ -4963,7 +4962,7 @@ End Rem
 				End If
 			End If
 
-			InternalErr
+			InternalErr "TCTranslator.TransIfcConstExpr"
 		End If
 
 		If TObjectType(expr.exprType) Then

--- a/decl.bmx
+++ b/decl.bmx
@@ -351,7 +351,7 @@ Type TDecl
 	End Method
 	
 	Method GenInstance:TDecl()
-		InternalErr
+		InternalErr "TDecl.GenInstance"
 	End Method
 	
 	Method OnSemant() Abstract
@@ -430,7 +430,7 @@ Type TValDecl Extends TDecl
 				SemantInit()
 			End If
 		Else
-			InternalErr
+			InternalErr "TValDecl.OnSemant"
 		EndIf
 		
 	End Method
@@ -869,7 +869,7 @@ Type TScopeDecl Extends TDecl
 'Public
 
 	Method OnCopy:TDecl(deep:Int = True)
-		InternalErr
+		InternalErr "TScopeDecl.OnCopy"
 	End Method
 
 	Method Decls:TList()
@@ -927,7 +927,7 @@ Type TScopeDecl Extends TDecl
 	
 	Method InsertDecl( decl:TDecl, isCopy:Int = False )
 
-		If decl.scope And Not (decl.attrs & DECL_INITONLY) And Not isCopy InternalErr
+		If decl.scope And Not (decl.attrs & DECL_INITONLY) And Not isCopy InternalErr "TScopeDecl.InsertDecl"
 		
 		'Local ident$=decl.ident
 		If Not decl.ident Return
@@ -2340,7 +2340,7 @@ Type TClassDecl Extends TScopeDecl
 	End Method
 	
 	Method OnCopy:TDecl(deep:Int = True)
-		InternalErr
+		InternalErr "TClassDecl.OnCopy"
 	End Method
 	
 	Method ToString$()
@@ -2429,7 +2429,7 @@ Rem
 End Rem
 	Method GenClassInstance:TClassDecl( instArgs:TType[], declImported:Int = False, callback:TCallback = Null, templateDets:TTemplateDets = Null )
 
-		If instanceof InternalErr
+		If instanceof InternalErr "TClassDecl.GenClassInstance"
 		
 		'no args
 		If Not instArgs

--- a/expr.bmx
+++ b/expr.bmx
@@ -31,11 +31,11 @@ Type TExpr
 	End Method
 
 	Method Copy:TExpr()
-		InternalErr
+		InternalErr "TExpr.Copy"
 	End Method
 
 	Method Semant:TExpr()
-		InternalErr
+		InternalErr "TExpr.Semant"
 	End Method
 
 	Method SemantSet:TExpr( op$,rhs:TExpr )
@@ -71,7 +71,7 @@ Type TExpr
 	End Method
 
 	Method TransVar$()
-		InternalErr
+		InternalErr "TExpr.TransVar"
 	End Method
 
 	'semant and cast
@@ -629,7 +629,7 @@ Type TVarExpr Extends TExpr
 
 	Method Semant:TExpr()
 		If exprType Return Self
-		If Not decl.IsSemanted() InternalErr
+		If Not decl.IsSemanted() InternalErr "TVarExpr.Semant"
 		exprType=decl.ty
 		Return Self
 	End Method
@@ -670,7 +670,7 @@ Type TMemberVarExpr Extends TExpr
 
 	Method Semant:TExpr()
 		If exprType Return Self
-		If Not decl.IsSemanted() InternalErr
+		If Not decl.IsSemanted() InternalErr "TMemberVarExpr.Semant"
 		exprType=decl.ty
 		Return Self
 	End Method
@@ -1265,7 +1265,7 @@ Type TCastExpr Extends TExpr
 						End If
 					End If
 				Else
-					InternalErr
+					InternalErr "TCastExpr.Semant"
 				EndIf
 				Local fdecl:TFuncDecl=src.GetClass().FindFuncDecl( op,,,,,,SCOPE_ALL )
 				expr=New TInvokeMemberExpr.Create( expr,fdecl ).Semant()
@@ -1701,7 +1701,7 @@ Type TUnaryExpr Extends TExpr
 			expr=expr.SemantAndCast( New TBoolType,CAST_EXPLICIT )
 			exprType=New TBoolType
 		Default
-			InternalErr
+			InternalErr "TUnaryExpr.Semant"
 		End Select
 
 		If TConstExpr( expr ) Return EvalConst()
@@ -1722,7 +1722,7 @@ Type TUnaryExpr Extends TExpr
 			If val Return ""
 			Return "1"
 		End Select
-		InternalErr
+		InternalErr "TUnaryExpr.Eval"
 	End Method
 
 	Method Trans$()
@@ -1934,7 +1934,7 @@ Type TBinaryMathExpr Extends TBinaryExpr
 				Return lhs+rhs
 			End Select
 		EndIf
-		InternalErr
+		InternalErr "TBinaryMathExpr.Eval"
 	End Method
 
 End Type
@@ -2053,7 +2053,7 @@ Type TBinaryCompareExpr Extends TBinaryExpr
 		EndIf
 		If r=1 Return "1"
 		If r=0 Return ""
-		InternalErr
+		InternalErr "TBinaryCompareExpr.Eval"
 	End Method
 End Type
 
@@ -2089,7 +2089,7 @@ Type TBinaryLogicExpr Extends TBinaryExpr
 		Case "and" If lhs.Eval() And rhs.Eval() Return "1" Else Return ""
 		Case "or"  If lhs.Eval() Or rhs.Eval() Return "1" Else Return ""
 		End Select
-		InternalErr
+		InternalErr "TBinaryLogicExpr.Eval"
 	End Method
 End Type
 
@@ -2466,7 +2466,7 @@ Type TIdentTypeExpr Extends TExpr
 		Else
 			cdecl=exprType.GetClass()
 		End If
-		If Not cdecl InternalErr
+		If Not cdecl InternalErr "TIdentTypeExpr.Semant"
 	End Method
 
 	Method Semant:TExpr()
@@ -2599,7 +2599,7 @@ Type TIdentExpr Extends TExpr
 	End Method
 
 	Method IsVar()
-		InternalErr
+		InternalErr "TIdentExpr.IsVar"
 	End Method
 
 	Method Semant:TExpr()
@@ -2692,7 +2692,7 @@ Type TIdentExpr Extends TExpr
 			Case "*","/","shl","shr","+","-","&","|","~~"
 				rhs=New TBinaryMathExpr.Create( bop,lhs,rhs )
 			Default
-				InternalErr
+				InternalErr "TIdentExpr.SemantSet"
 			End Select
 			rhs=rhs.Semant()
 		EndIf

--- a/parser.bmx
+++ b/parser.bmx
@@ -302,7 +302,7 @@ Type TForEachinStmt Extends TLoopStmt
 			End If
 
 		Else
-			InternalErr
+			InternalErr "TForEachinStmt.OnSemant"
 		EndIf
 
 		block.Semant

--- a/stmt.bmx
+++ b/stmt.bmx
@@ -236,7 +236,7 @@ Type TExprStmt Extends TStmt
 		
 	Method OnSemant()
 		expr=expr.Semant()
-		If Not expr InternalErr
+		If Not expr InternalErr "TExprStmt.OnSemant"
 	End Method
 
 	Method Trans$()

--- a/translator.bmx
+++ b/translator.bmx
@@ -81,7 +81,7 @@ Type TTranslator
 		End If
 		ind :- 1
 		If ind < 0 Then
-			InternalErr
+			InternalErr "TTranslator.PopLoopLocalStack"
 		End If
 		localScope.Pop
 	End Method
@@ -705,7 +705,7 @@ End Rem
 		Case "~~" Return op
 		Case "not" Return "!"
 		End Select
-		InternalErr
+		InternalErr "TTranslator.TransUnaryOp"
 	End Method
 	
 	Method TransBinaryOp$( op$,rhs$ )
@@ -732,7 +732,7 @@ op = mapSymbol(op)
 		Case "<<", ">>" Return Op
 		Case "%" Return Op
 		End Select
-		InternalErr
+		InternalErr "TTranslator.TransBinaryOp"
 	End Method
 	
 	Method TransAssignOp$( op$ )
@@ -758,7 +758,7 @@ op = mapSymbol(op)
 			Select TUnaryExpr( expr ).op
 			Case "+","-","~~","not" Return 3
 			End Select
-			InternalErr
+			InternalErr "TTranslator.ExprPri"
 		Else If TBinaryExpr( expr )
 			Select TBinaryExpr( expr ).op
 			Case "^" Return 4
@@ -773,7 +773,7 @@ op = mapSymbol(op)
 			Case "and" Return 13
 			Case "or" Return 14
 			End Select
-			InternalErr
+			InternalErr "TTranslator.ExprPri"
 		EndIf
 		Return 2
 	End Method
@@ -953,7 +953,7 @@ End Rem
 		
 		If TGlobalDecl( decl ) Return TransGlobal( TGlobalDecl( decl ) )
 		
-		InternalErr
+		InternalErr "TTranslator.TransVarExpr"
 	End Method
 	
 	Method TransMemberVarExpr$( expr:TMemberVarExpr )
@@ -965,7 +965,7 @@ End Rem
 
 		If TGlobalDecl( decl ) Return TransGlobal( TGlobalDecl( decl ) )
 
-		InternalErr
+		InternalErr "TTranslator.TransMemberVarExpr"
 	End Method
 	
 	Method TransInvokeExpr$( expr:TInvokeExpr )
@@ -996,7 +996,7 @@ End Rem
 			Return TransFunc( TFuncDecl(decl),expr.args,Null )
 		End If
 		
-		InternalErr
+		InternalErr "TTranslator.TransInvokeExpr"
 	End Method
 	
 	Method TransInvokeMemberExpr$( expr:TInvokeMemberExpr )
@@ -1013,7 +1013,7 @@ End Rem
 			Return TransFunc( TFuncDecl(decl),expr.args,expr.expr )	
 		End If
 		
-		InternalErr
+		InternalErr "TTranslator.TransInvokeMemberExpr"
 	End Method
 	
 	Method TransInvokeSuperExpr$( expr:TInvokeSuperExpr )
@@ -1030,7 +1030,7 @@ End Rem
 			If decl Return TransSuperFunc( TFuncDecl( expr.funcDecl ),expr.args, expr.classScope )
 		End If
 		
-		InternalErr
+		InternalErr "TTranslator.TransInvokeSuperExpr"
 	End Method
 	
 	Method TransFuncCallExpr:String( expr:TFuncCallExpr )
@@ -1050,7 +1050,7 @@ End Rem
 			Return expr.expr.Trans() + TransArgs(expr.args, TFuncDecl(decl))
 		End If
 		
-		InternalErr
+		InternalErr "TTranslator.TransFuncCallExpr"
 	End Method
 	
 	Method TransExprStmt$( stmt:TExprStmt )
@@ -1183,7 +1183,7 @@ End Rem
 				Next
 				Emit "goto " + TransLabelCont(bc, False)
 			Else
-				InternalErr
+				InternalErr "TTranslator.TransContinueStmt"
 			End If
 		Else
 		 	' For debug builds, we need to rollback the local scope stack correctly
@@ -1202,7 +1202,7 @@ End Rem
 					Next
 					Emit "goto " + TransLabelCont(bc, False)
 				Else
-					InternalErr
+					InternalErr "TTranslator.TransContinueStmt"
 				End If
 			Else
 				If opt_debug And stmt.loop And Not stmt.loop.block.IsNoDebug() Then
@@ -1264,7 +1264,7 @@ End Rem
 				Next
 				Emit "goto " + TransLabelExit(bc, False)
 			Else
-				InternalErr
+				InternalErr "TTranslator.TransBreakStmt"
 			End If
 		Else
 		 	' For debug builds, we need to rollback the local scope stack correctly
@@ -1283,7 +1283,7 @@ End Rem
 					Next
 					Emit "goto " + TransLabelExit(bc, False)
 				Else
-					InternalErr
+					InternalErr "TTranslator.TransBreakStmt"
 				End If
 			Else
 				If opt_debug And stmt.loop And Not stmt.loop.block.IsNoDebug() Then
@@ -1551,7 +1551,7 @@ End Rem
 			If gdecl.inited Return Null
 			Return TransGlobalDecl( gdecl )
 		End If
-		InternalErr
+		InternalErr "TTranslator.TransDeclStmt"
 	End Method
 	
 	Method TransIfStmt$( stmt:TIfStmt )

--- a/type.bmx
+++ b/type.bmx
@@ -1522,15 +1522,15 @@ Type TIdentType Extends TType
 	End Method
 	
 	Method ActualType:TType()
-		InternalErr
+		InternalErr "TIdentType.ActualType"
 	End Method
 	
 	Method EqualsType:Int( ty:TType )
-		InternalErr
+		InternalErr "TIdentType.EqualsType"
 	End Method
 	
 	Method ExtendsType:Int( ty:TType, noExtendString:Int = False, widensTest:Int = False )
-		InternalErr
+		InternalErr "TIdentType.ExtendsType"
 	End Method
 	
 	'Method Semant:TType()


### PR DESCRIPTION
This adds a string parameter to InternalErr to identify which of the many InternalErr calls in bcc caused a particular error. It might help finding and fixing internal errors, especially if they're reported by users that experience them using release builds of bcc.