### PR TITLE
Add issue template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,23 @@
+Note: For bugs, please tell us the expected and actual behavior. Delete whatever doesn't apply to your case.
+
+
+# Feature Request
+
+Please tell us about your motivation and use case. 
+
+
+# Bug Report
+
+Please provide the steps to reproduce and if possible a minimal demo of the problem, for example by attaching a zip file to this issue.
+
+## Expected Behavior 
+
+
+## Actual Behavior
+
+
+## Environment
+
+- Operating System:
+- Output of `bcc -v`: 
+- Optional additional info, download, project links, etc


### PR DESCRIPTION
I forgot that `bcc` is cross-platform and that I should provide some basic info about my environment. Figured an issue template could help.

I added some other template stuff above the environment part. If you think that's too much, I can just as well delete everything except the bullet points at the bottom.