### PR TITLE
Create macOS build of bcc using Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,14 +15,11 @@ install:
 
 script:
   - ./BlitzMax/bin/bmk
-    makeapp -a -r -standalone
+    makeapp -a -r
     -l ${PLATFORM}
     -g ${CPU}
     -o ./bcc
     ./bcc.bmx
-  - BUILD_SCRIPT="bcc.console.release.${PLATFORM}.${CPU}.build"
-  - chmod +x "./${BUILD_SCRIPT}"
-  - ./${BUILD_SCRIPT}
 
 after_success:
   - BCC_VERSION=`./bcc -v | sed 's/^.*\([0-9][0-9]*\.[0-9][0-9]*\).*/\1/'`

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,11 +28,6 @@ after_success:
   - BCC_VERSION=`./bcc -v | sed 's/^.*\([0-9][0-9]*\.[0-9][0-9]*\).*/\1/'`
   - ZIP_FILENAME="bcc-v${BCC_VERSION}-${PLATFORM}-${CPU}.zip"
   - echo "Zipping $ZIP_FILENAME"
-  - zip "$ZIP_FILENAME" bcc
-  - echo ZIP_FILENAME > .zip_filename.txt
-    # Export the filename because the deploy section cannot access
-    # vars from here.
-
-before_deploy:
-  - export ZIP_FILENAME=$(cat .zip_filename.txt)
+  - mkdir -p "archive"
+  - zip "archive/$ZIP_FILENAME" bcc
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@ script:
     -g ${CPU}
     -o ./bcc
     ./bcc.bmx
-  - export RESULT="bcc.console.release.${PLATFORM}.${CPU}.build"
-  - chmod +x "./${RESULT}"
+  - BUILD_SCRIPT="bcc.console.release.${PLATFORM}.${CPU}.build"
+  - ./sh BUILD_SCRIPT
 
 after_success:
   - ls -la
-  - ./${RESULT} -v
+  - ./bcc -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,17 +16,19 @@ install:
   - unzip "`basename "${STABLE}"`"
 
 script:
+  - mkdir -p "build"
   - ./BlitzMax/bin/bmk
     makeapp -a -r
     -l ${PLATFORM}
     -g ${CPU}
-    -o ./bcc
+    -o ./build/bcc
     ./bcc.bmx
 
 after_success:
+  - cd ./build
   - BCC_VERSION=`./bcc -v | sed 's/^.*\([0-9][0-9]*\.[0-9][0-9]*\).*/\1/'`
   - ZIP_FILENAME="bcc-v${BCC_VERSION}-${PLATFORM}-${CPU}.zip"
   - echo "Zipping $ZIP_FILENAME"
-  - mkdir -p "archive"
-  - zip "archive/$ZIP_FILENAME" bcc
+  - zip "$ZIP_FILENAME" bcc
+  - ls -la
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,5 @@ script:
   - export RESULT="bcc.console.release.${PLATFORM}.${CPU}.build"
 
 after_success:
-  - $RESULT -v
+  - ls -la
+  - ./$RESULT -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,11 +24,21 @@ script:
     -o ./build/bcc
     ./bcc.bmx
 
-after_success:
+before_deploy:
   - cd ./build
-  - BCC_VERSION=`./bcc -v | sed 's/^.*\([0-9][0-9]*\.[0-9][0-9]*\).*/\1/'`
-  - ZIP_FILENAME="bcc-v${BCC_VERSION}-${PLATFORM}-${CPU}.zip"
+  - ZIP_FILENAME="bcc-${TRAVIS_TAG}-${PLATFORM}-${CPU}.zip"
   - echo "Zipping $ZIP_FILENAME"
   - zip "$ZIP_FILENAME" bcc
   - ls -la
+  - cd ..
 
+deploy:
+  provider: releases
+  file_glob: true
+  file: build/*.zip
+  skip_cleanup: true
+  draft: true
+  on:
+    all_branches: true
+    tags: true
+    condition: '$TRAVIS_TAG =~ ^v[0-9]'

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,3 +29,10 @@ after_success:
   - ZIP_FILENAME="bcc-v${BCC_VERSION}-${PLATFORM}-${CPU}.zip"
   - echo "Zipping $ZIP_FILENAME"
   - zip "$ZIP_FILENAME" bcc
+  - echo ZIP_FILENAME > .zip_filename.txt
+    # Export the filename because the deploy section cannot access
+    # vars from here.
+
+before_deploy:
+  - export ZIP_FILENAME=$(cat .zip_filename.txt)
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,13 @@ install:
 script:
   - ./BlitzMax/bin/bmk
     makeapp -a -r -standalone
-    -l $PLATFORM
-    -g $CPU
+    -l ${PLATFORM}
+    -g ${CPU}
     -o ./bcc
     ./bcc.bmx
   - export RESULT="bcc.console.release.${PLATFORM}.${CPU}.build"
+  - chmod +x "./${RESULT}"
 
 after_success:
   - ls -la
-  - ./$RESULT -v
+  - ./${RESULT} -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+env:
+  global:
+    - LC_CTYPE=en_US.UTF-8
+    - LANG=en_US.UTF-8
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode10.2
+      env: PLATFORM="macos" CPU="x64" STABLE="https://github.com/bmx-ng/bmx-ng/releases/download/v0.99.3.31.macos/BlitzMax_macos_0.99.3.31.zip"
+
+install:
+  - wget "${STABLE}"
+  - unzip "`basename "${STABLE}"`"
+
+script:
+  - ./BlitzMax/bin/bmk
+    makeapp -a -r -standalone
+    -l $PLATFORM
+    -g $CPU
+    -o ./bcc
+    ./bcc.bmx
+  - export RESULT="bcc.console.release.${PLATFORM}.${CPU}.build"
+
+after_success:
+  - $RESULT -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,8 @@ script:
     -o ./bcc
     ./bcc.bmx
   - BUILD_SCRIPT="bcc.console.release.${PLATFORM}.${CPU}.build"
-  - ./sh BUILD_SCRIPT
+  - chmod +x "./${BUILD_SCRIPT}"
+  - ./${BUILD_SCRIPT}
 
 after_success:
   - ls -la

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+language: c
+
 env:
   global:
     - LC_CTYPE=en_US.UTF-8

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,7 @@ script:
   - ./${BUILD_SCRIPT}
 
 after_success:
-  - ls -la
-  - ./bcc -v
+  - BCC_VERSION=`./bcc -v | sed 's/^.*\([0-9][0-9]*\.[0-9][0-9]*\).*/\1/'`
+  - ZIP_FILENAME="bcc-v${BCC_VERSION}-${PLATFORM}-${CPU}.zip"
+  - echo "Zipping $ZIP_FILENAME"
+  - zip "$ZIP_FILENAME" bcc


### PR DESCRIPTION
This instructs Travis CI to

1. check out the latest stable release from the website, 
2. this repository's source, 
3. compile the source with the downloaded `bcc` using `bmk`

So far, this only _builds_ bcc and validates that the code is build-able. It does not on its own produce a release. @woollybah would need to set up Travis CI for this repo first and then I could add a couple of steps. I'm experimenting with the auto-release-functionality at the moment in my fork.

Would be a great help if Travis is configured and building bcc is part of this upstream repo's `master` branch. Then we could iterate on creating cross-platform auto-built release files.