### PR TITLE
Make bcc compile again

### DIFF
--- a/iparser.bmx
+++ b/iparser.bmx
@@ -586,7 +586,7 @@ Type TIParser
 		Forever
 		
 		' semant imported classes
-		For Local cdecl:TClassDecl = EachIn _mod.decls
+		For Local cdecl:TClassDecl = EachIn _mod.Decls()
 			cdecl.Semant()
 			If Not cdecl.args Then
 				cdecl.FinalizeClass()


### PR DESCRIPTION
bcc currently fails to build, except when using NG to do it, because in that case the error in the code is cancelled out by a bug in NG bcc.
https://github.com/bmx-ng/bcc/blob/c75c3205bf9416cfe2ace1953f560e2bcf30e6a6/iparser.bmx#L589 `_mod.decls` just refers to a method - it needs to actually get called for the code to be correct.