### PR TITLE
Validate array index count

### DIFF
--- a/expr.bmx
+++ b/expr.bmx
@@ -2490,6 +2490,10 @@ Type TIndexExpr Extends TExpr
 		Else If TArrayType( expr.exprType )
 			exprType= TArrayType( expr.exprType ).elemType
 
+			If index.Length <> TArrayType( expr.exprType ).dims Then
+				Err "Wrong number of indices for array. Expected " + TArrayType( expr.exprType ).dims + ", got " + index.Length
+			End If
+
 			If TArrayType( expr.exprType ).dims > 1 Then
 
 				' a multi-dimensional array of arrays is slightly more complex


### PR DESCRIPTION
Adds a check to ensure the number of indices provided matches the dimensions of the array being accessed.

This prevents potential runtime errors caused by incorrect array indexing.