### PR TITLE
Uses opt_apptype instead of opt_buildtype

### DIFF
--- a/ctranslator.bmx
+++ b/ctranslator.bmx
@@ -7137,7 +7137,7 @@ End If
 			End If
 		Next
 
-		If opt_buildtype = BUILDTYPE_APP Then
+		If opt_apptype Then
 			Emit "bbRunAtstart();"
 		End If
 


### PR DESCRIPTION
Uses the `opt_apptype` variable for condition, ensuring the correct code path is taken when determining whether to emit the "bbRunAtstart();" line. This corrects a logical error where the wrong build type check was being performed, preventing the application from starting correctly.