### PR TITLE
Adds HashCode support to classes

### DIFF
--- a/config.bmx
+++ b/config.bmx
@@ -753,6 +753,7 @@ Extern
 	Function strlen_:Int(s:Byte Ptr)="strlen"
 	Function bmx_enum_next_power(char:Int, val:Long Var, ret:Long Var)
 	Function bmx_gen_hash:String(txt:String)
+	Function bmx_gen_hash32:String(txt:String)
 	Function bmx_hash_createState:Byte Ptr()
 	Function bmx_hash_reset(state:Byte Ptr)
 	Function bmx_hash_update(state:Byte Ptr, data:Byte Ptr, length:Int)

--- a/hash.c
+++ b/hash.c
@@ -14,6 +14,13 @@ BBString * bmx_gen_hash(BBString * txt) {
 	return bbStringFromCString(buf);
 }
 
+BBString * bmx_gen_hash32(BBString * txt) {
+	char buf[64];
+	XXH64_hash_t hash = XXH3_64bits(txt->buf, txt->length * sizeof(BBChar));
+	snprintf(buf, 64, "0x%x", (uint32_t)(hash ^ (hash >> 32)));
+	return bbStringFromCString(buf);
+}
+
 XXH3_state_t * bmx_hash_createState() {
 	return XXH3_createState();
 }

--- a/translator.bmx
+++ b/translator.bmx
@@ -327,7 +327,7 @@ Type TTranslator
 			Return func.equalsBuiltIn
 		End If
 	
-		If checked Or func.IdentLower() = "tostring" Or func.IdentLower() = "compare" Or func.IdentLower() = "sendmessage" Or func.IdentLower() = "new" Or func.IdentLower() = "delete" Then
+		If checked Or func.IdentLower() = "tostring" Or func.IdentLower() = "compare" Or func.IdentLower() = "sendmessage" Or func.IdentLower() = "new" Or func.IdentLower() = "delete" Or func.IdentLower() = "hashcode" Then
 			If classDecl.munged = "bbObjectClass" Then
 				For Local decl:TFuncDecl = EachIn classDecl.Decls()
 					If Not decl.IsSemanted() Then


### PR DESCRIPTION
Implements HashCode support for classes, including:

- Adds a new bmx_gen_hash32 function for generating 32-bit hashes.
- Updates the CTranslator to handle HashCode methods in classes.
- Includes HashCode in the reserved methods list.
- Modifies the emission of class functions to include HashCode.
- Updates the generation of string structs to use the 32 bit hash and the correct type.